### PR TITLE
registration and cancellation limits for sessions

### DIFF
--- a/admin/session_edit.php
+++ b/admin/session_edit.php
@@ -125,6 +125,7 @@ if ($proceed) {
             $edit['session_reminder_hours']=$settings['session_reminder_hours_default'];
             $edit['send_reminder_on']=$settings['session_reminder_send_on_default'];
             $edit['registration_end_hours']=$settings['session_registration_end_hours_default'];
+            $edit['cancellation_end_hours']=$settings['session_cancellation_end_hours_default'];
             $session_time=0;
 
             $edit['part_needed']=$settings['lab_participants_default'];
@@ -256,6 +257,17 @@ if ($proceed) {
     helpers__select_numbers_relative("registration_end_hours",$edit['registration_end_hours'],0,
                     $settings['session_registration_end_hours_max'],2,
                     $settings['session_registration_end_hours_steps'],$session_time);
+    echo '
+            </TD>
+        </TR>';
+    echo '  <TR>
+            <TD>
+                '.lang('cancellation_end_hours_before').':
+            </TD>
+            <TD>';
+    helpers__select_numbers_relative("cancellation_end_hours",$edit['cancellation_end_hours'],0,
+                    $settings['session_cancellation_end_hours_max'],2,
+                    $settings['session_cancellation_end_hours_steps'],$session_time);
     echo '
             </TD>
         </TR>';

--- a/config/system.php
+++ b/config/system.php
@@ -434,6 +434,20 @@ $system__options_general[]=array(
 );
 
 $system__options_general[]=array(
+'option_name'=>'include_cancel_until_in_invitation',
+'option_text'=>'Include "cancel until ..." in session list in invitation email?',
+'type'=>'select_yesno_switchy',
+'default_value'=>'y'
+);
+
+$system__options_general[]=array(
+'option_name'=>'include_cancel_until_on_enrolment_page',
+'option_text'=>'Include "cancel until ..." in session list on enrolment webpage?',
+'type'=>'select_yesno_switchy',
+'default_value'=>'y'
+);
+
+$system__options_general[]=array(
 'option_name'=>'include_weekday_in_session_name',
 'option_text'=>'Include weekday in session date whereever displayed?',
 'type'=>'select_yesno_switchy',

--- a/config/system.php
+++ b/config/system.php
@@ -575,15 +575,6 @@ $system__options_general[]=array(
 );
 
 $system__options_general[]=array(
-'option_name'=>'subject_cancellation_hours_before_start',
-'option_text'=>'If yes: Allow cancellation until how many hours before session start?',
-'type'=>'textline',
-'default_value'=>'6',
-'size'=>'3',
-'maxlength'=>'3',
-);
-
-$system__options_general[]=array(
 'option_name'=>'subject_cancellation_participation_status',
 'option_text'=>'If yes: Participation status to be assigned to subjects who canceled their session enrollment',
 'type'=>'plain',

--- a/config/system.php
+++ b/config/system.php
@@ -1122,7 +1122,6 @@ $system__options_defaults[]=array(
 'maxlength'=>'3',
 );
 
-
 $system__options_defaults[]=array(
 'option_name'=>'session_registration_end_hours_default',
 'option_text'=>'Experiment Session: registration end: default hours before session?',
@@ -1131,6 +1130,38 @@ $system__options_defaults[]=array(
 'value_begin'=>'0',
 'value_end'=>'func:$options["session_registration_end_hours_max"]',
 'value_step'=>'func:$options["session_registration_end_hours_steps"]',
+'values_reverse'=>'n',
+'include_none_option'=>'n'
+);
+
+$system__options_defaults[]=array('type'=>'line');
+
+$system__options_defaults[]=array(
+'option_name'=>'session_cancellation_end_hours_max',
+'option_text'=>'Experiment Session: cancellation end: max hours before session?',
+'type'=>'textline',
+'default_value'=>'240',
+'size'=>'3',
+'maxlength'=>'3',
+);
+
+$system__options_defaults[]=array(
+'option_name'=>'session_cancellation_end_hours_steps',
+'option_text'=>'Experiment Session: cancellation end: steps for hours before session?',
+'type'=>'textline',
+'default_value'=>'12',
+'size'=>'3',
+'maxlength'=>'3',
+);
+
+$system__options_defaults[]=array(
+'option_name'=>'session_cancellation_end_hours_default',
+'option_text'=>'Experiment Session: cancellation end: default hours before session?',
+'type'=>'select_numbers',
+'default_value'=>'24',
+'value_begin'=>'0',
+'value_end'=>'func:$options["session_cancellation_end_hours_max"]',
+'value_step'=>'func:$options["session_cancellation_end_hours_steps"]',
 'values_reverse'=>'n',
 'include_none_option'=>'n'
 );

--- a/pesa_migration/pesa_add_new_lang_symbols.sql
+++ b/pesa_migration/pesa_add_new_lang_symbols.sql
@@ -44,7 +44,7 @@ insert into ##new_db##.or_lang
 select max(lang_id)+1 ,'y', -1, 'lang', 'you_have_to_year_of_birth', 'Please enter your year of birth.', 'Bitte geben Sie Ihr Geburtsjahr an.' from ##new_db##.or_lang;
 
 insert into ##new_db##.or_lang
-select max(lang_id)+1 ,'y', -1, 'lang', 'cancellation_end_hours_before', 'Cancellation deadline (hours before start)', 'Abmeldungsende (Stunden vor Experimentbeginn)' from ##new_db##.or_lang;
+select max(lang_id)+1 ,'y', -1, 'lang', 'cancellation_end_hours_before', 'Cancellation deadline (hours before session start)', 'Abmeldungsende (Stunden vor Sessionbeginn)' from ##new_db##.or_lang;
 
 insert into ##new_db##.or_lang
 select max(lang_id)+1 ,'y', -1, 'lang', 'cancellation_until', 'cancel until', 'Abmeldung bis' from ##new_db##.or_lang;

--- a/pesa_migration/pesa_add_new_lang_symbols.sql
+++ b/pesa_migration/pesa_add_new_lang_symbols.sql
@@ -45,3 +45,6 @@ select max(lang_id)+1 ,'y', -1, 'lang', 'you_have_to_year_of_birth', 'Please ent
 
 insert into ##new_db##.or_lang
 select max(lang_id)+1 ,'y', -1, 'lang', 'cancellation_end_hours_before', 'Cancellation deadline (hours before start)', 'Abmeldungsende (Stunden vor Experimentbeginn)' from ##new_db##.or_lang;
+
+insert into ##new_db##.or_lang
+select max(lang_id)+1 ,'y', -1, 'lang', 'cancellation_until', 'cancel until', 'Abmeldung bis' from ##new_db##.or_lang;

--- a/pesa_migration/pesa_add_new_lang_symbols.sql
+++ b/pesa_migration/pesa_add_new_lang_symbols.sql
@@ -42,3 +42,6 @@ select max(lang_id)+1 ,'y', -1, 'lang', 'year_of_birth', 'year of birth', 'Gebur
 
 insert into ##new_db##.or_lang
 select max(lang_id)+1 ,'y', -1, 'lang', 'you_have_to_year_of_birth', 'Please enter your year of birth.', 'Bitte geben Sie Ihr Geburtsjahr an.' from ##new_db##.or_lang;
+
+insert into ##new_db##.or_lang
+select max(lang_id)+1 ,'y', -1, 'lang', 'cancellation_end_hours_before', 'Cancellation deadline (hours before start)', 'Abmeldungsende (Stunden vor Experimentbeginn)' from ##new_db##.or_lang;

--- a/pesa_migration/pesa_add_new_options.sql
+++ b/pesa_migration/pesa_add_new_options.sql
@@ -21,3 +21,11 @@ from ##new_db##.or_options;
 insert into ##new_db##.or_options (option_id, option_type, option_name, option_value) 
 select max(option_id)+1 ,'default', 'session_cancellation_end_hours_max', '240'
 from ##new_db##.or_options;
+
+insert into ##new_db##.or_options (option_id, option_type, option_name, option_value)
+select max(option_id)+1 ,'default', 'include_cancel_until_in_invitation', 'y'
+from ##new_db##.or_options;
+
+insert into ##new_db##.or_options (option_id, option_type, option_name, option_value)
+select max(option_id)+1 ,'default', 'include_cancel_until_on_enrolment_page', 'y'
+from ##new_db##.or_options;

--- a/pesa_migration/pesa_add_new_options.sql
+++ b/pesa_migration/pesa_add_new_options.sql
@@ -9,3 +9,15 @@ from ##new_db##.or_options;
 insert into ##new_db##.or_options (option_id, option_type, option_name, option_value) 
 select max(option_id)+1 ,'general', 'use_experimenters_mail_as_default', 'y'
 from ##new_db##.or_options;
+
+insert into ##new_db##.or_options (option_id, option_type, option_name, option_value) 
+select max(option_id)+1 ,'default', 'session_cancellation_end_hours_default', '24'
+from ##new_db##.or_options;
+
+insert into ##new_db##.or_options (option_id, option_type, option_name, option_value) 
+select max(option_id)+1 ,'default', 'session_cancellation_end_hours_steps', '12'
+from ##new_db##.or_options;
+
+insert into ##new_db##.or_options (option_id, option_type, option_name, option_value) 
+select max(option_id)+1 ,'default', 'session_cancellation_end_hours_max', '240'
+from ##new_db##.or_options;

--- a/pesa_migration/pesa_extend_sessions.sql
+++ b/pesa_migration/pesa_extend_sessions.sql
@@ -1,0 +1,1 @@
+alter table ##new_db##.or_sessions add cancellation_end_hours int(11) not null default 24;

--- a/pesa_migration/pesa_remove_options.sql
+++ b/pesa_migration/pesa_remove_options.sql
@@ -1,0 +1,1 @@
+delete from ##new_db##.or_options where option_name = 'subject_cancellation_hours_before_start';

--- a/pesa_migration/pesa_set_options.sql
+++ b/pesa_migration/pesa_set_options.sql
@@ -10,6 +10,7 @@ update ##new_db##.or_options set option_value = 24  where (option_id = '14260121
 update ##new_db##.or_options set option_value = 0   where (option_id = '1426012100'); /* set reserve participant default */
 update ##new_db##.or_options set option_value = 1   where (option_id = '1426012098'); /* set participant default */
 update ##new_db##.or_options set option_value = 24  where (option_id = '1426012107'); /* set default registration end in hours before session start */
+update ##new_db##.or_options set option_value = 'y' where (option_id = '1426010284'); /* enable registration deadline in emails */
 /* update pesa2019.or_options set option_value = '<insert-email-here>' where (option_id = '1426010269'); /* support mail */
 
 /* enable noshow warnings */

--- a/pesa_migration/pesa_set_options.sql
+++ b/pesa_migration/pesa_set_options.sql
@@ -9,6 +9,7 @@ update ##new_db##.or_options set option_value = 'y' where (option_id = '14260103
 update ##new_db##.or_options set option_value = 24  where (option_id = '1426012101'); /* set max session duration hour default */
 update ##new_db##.or_options set option_value = 0   where (option_id = '1426012100'); /* set reserve participant default */
 update ##new_db##.or_options set option_value = 1   where (option_id = '1426012098'); /* set participant default */
+update ##new_db##.or_options set option_value = 24  where (option_id = '1426012107'); /* set default registration end in hours before session start */
 /* update pesa2019.or_options set option_value = '<insert-email-here>' where (option_id = '1426010269'); /* support mail */
 
 /* enable noshow warnings */

--- a/pesa_migration/pesa_transfer.sh
+++ b/pesa_migration/pesa_transfer.sh
@@ -42,7 +42,8 @@ pesa_add_new_options.sql
 pesa_add_new_lang_symbols.sql
 pesa_add_new_public_content.sql
 pesa_extend_admin.sql
-pesa_update_error_message.sql)
+pesa_update_error_message.sql
+pesa_remove_options.sql)
 
 # transfering or_admin, this requires a .htaccess file
 cat ./pesa_transfer_admin.sh | sed "s/##new_db##/$new_db/g" | sed "s/##old_db##/$old_db/g" | bash

--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -164,6 +164,10 @@ function experimentmail__get_session_list($experiment_id,$tlang="") {
                 $list.=', '.lang('registration_until').' '.
                     ortime__format($registration_unixtime,'',lang('lang'));
             }
+            if (or_setting('include_cancel_until_in_invitation')) {
+                $list.=', '.lang('registration_until').' '.
+                    ortime__format(sessions__get_cancellation_end($s),'',lang('lang'));
+            }
             $list.="\n";
         }
     }

--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -166,7 +166,7 @@ function experimentmail__get_session_list($experiment_id,$tlang="") {
             }
             if (or_setting('include_cancel_until_in_invitation')) {
                 $list.=', '.lang('registration_until').' '.
-                    ortime__format(sessions__get_cancellation_end($s),'',lang('lang'));
+                    ortime__format(sessions__get_cancellation_deadline($s),'',lang('lang'));
             }
             $list.="\n";
         }

--- a/tagsets/expregister.php
+++ b/tagsets/expregister.php
@@ -21,7 +21,7 @@ function expregister__get_invitations($participant_id) {
     while ($varray = pdo_fetch_assoc($result)) {
         $varray['session_unixtime']=ortime__sesstime_to_unixtime($varray['session_start']);
         $varray['registration_unixtime']=sessions__get_registration_end($varray);
-        $varray['cancellation_unixtime']=sessions__get_cancellation_end($varray);
+        $varray['cancellation_unixtime']=sessions__get_cancellation_deadline($varray);
         $varray['session_full']=sessions__session_full("",$varray);
         $now=time();
         if( $now < $varray['session_unixtime']) {

--- a/tagsets/expregister.php
+++ b/tagsets/expregister.php
@@ -21,6 +21,7 @@ function expregister__get_invitations($participant_id) {
     while ($varray = pdo_fetch_assoc($result)) {
         $varray['session_unixtime']=ortime__sesstime_to_unixtime($varray['session_start']);
         $varray['registration_unixtime']=sessions__get_registration_end($varray);
+        $varray['cancellation_unixtime']=sessions__get_cancellation_end($varray);
         $varray['session_full']=sessions__session_full("",$varray);
         $now=time();
         if( $now < $varray['session_unixtime']) {
@@ -71,6 +72,10 @@ function expregister__list_invited_for($participant) {
         if (or_setting('include_sign_up_until_on_enrolment_page')) {
             echo ",  ".lang('registration_until')." ";
             echo ortime__format($s['registration_unixtime'],'',lang('lang'));
+        }
+        if (or_setting('include_cancel_until_on_enrolment_page')) {
+            echo ",  ".lang('cancellation_until')." ";
+            echo ortime__format($s['cancellation_unixtime'],'',lang('lang'));
         }
         if (or_setting('allow_public_session_note') && isset($s['public_session_note']) && trim($s['public_session_note'])) {
             echo '<BR><i>'.lang('note').': '.trim($s['public_session_note']).'</i>';

--- a/tagsets/sessions.php
+++ b/tagsets/sessions.php
@@ -291,25 +291,6 @@ function sessions__get_registration_end($alist,$session_id="",$experiment_id="")
     return ortime__sesstime_to_unixtime($registration_end);
 }
 
-function sessions__get_cancellation_end($alist,$session_id="",$experiment_id="") {
-    if ($session_id) {
-        $pars=array(':session_id'=>$session_id);
-        $query="SELECT * FROM ".table('sessions')." WHERE session_id=:session_id";
-        $alist=orsee_query($query,$pars);
-    } elseif ($experiment_id) {
-        $pars=array(':experiment_id'=>$experiment_id);
-        $query="SELECT ".table('sessions').".*
-            FROM ".table('experiments').", ".table('sessions')."
-            WHERE ".table('experiments').".experiment_id=".table('sessions').".experiment_id
-            AND experiment_type='laboratory'
-            AND ".table('experiments').".experiment_id=:experiment_id
-            ORDER BY session_start DESC
-            LIMIT 1";
-        $alist=orsee_query($query,$pars);
-    }
-    $cancellation_end = ortime__add_hourmin_to_sesstime($alist['session_start'],0-$alist['cancellation_end_hours']);
-    return ortime__sesstime_to_unixtime($cancellation_end);
-}
 
 function sessions__get_cancellation_deadline($alist,$session_id="",$experiment_id="") {
     global $settings;

--- a/tagsets/sessions.php
+++ b/tagsets/sessions.php
@@ -308,10 +308,7 @@ function sessions__get_cancellation_deadline($alist,$session_id="",$experiment_i
             LIMIT 1";
         $alist=orsee_query($query,$pars);
     }
-    if (isset($settings['subject_cancellation_hours_before_start']) && $settings['subject_cancellation_hours_before_start']>0)
-        $deadline_hours=$settings['subject_cancellation_hours_before_start'];
-    else $deadline_hours=0;
-    $cancellation__deadline=ortime__add_hourmin_to_sesstime($alist['session_start'],0-$deadline_hours);
+    $cancellation__deadline=ortime__add_hourmin_to_sesstime($alist['session_start'], 0-$alist['cancellation_end_hours']);
     return ortime__sesstime_to_unixtime($cancellation__deadline);
 }
 

--- a/tagsets/sessions.php
+++ b/tagsets/sessions.php
@@ -291,6 +291,26 @@ function sessions__get_registration_end($alist,$session_id="",$experiment_id="")
     return ortime__sesstime_to_unixtime($registration_end);
 }
 
+function sessions__get_cancellation_end($alist,$session_id="",$experiment_id="") {
+    if ($session_id) {
+        $pars=array(':session_id'=>$session_id);
+        $query="SELECT * FROM ".table('sessions')." WHERE session_id=:session_id";
+        $alist=orsee_query($query,$pars);
+    } elseif ($experiment_id) {
+        $pars=array(':experiment_id'=>$experiment_id);
+        $query="SELECT ".table('sessions').".*
+            FROM ".table('experiments').", ".table('sessions')."
+            WHERE ".table('experiments').".experiment_id=".table('sessions').".experiment_id
+            AND experiment_type='laboratory'
+            AND ".table('experiments').".experiment_id=:experiment_id
+            ORDER BY session_start DESC
+            LIMIT 1";
+        $alist=orsee_query($query,$pars);
+    }
+    $cancellation_end = ortime__add_hourmin_to_sesstime($alist['session_start'],0-$alist['cancellation_end_hours']);
+    return ortime__sesstime_to_unixtime($cancellation_end);
+}
+
 function sessions__get_cancellation_deadline($alist,$session_id="",$experiment_id="") {
     global $settings;
     if ($session_id) {


### PR DESCRIPTION
- individual cancellation deadline for each session
- default cancellation and registration deadline set to 24 hours before session start
- remove old cancellation option
- show cancellation and registration deadline in email and on enrolment page